### PR TITLE
1.3.2 Updates

### DIFF
--- a/files/js/editor_element.js
+++ b/files/js/editor_element.js
@@ -7,35 +7,10 @@
         initialize: function() {
             this.activeIndex = this.settings.get('active_index');
 
-            this.fixStyles();
+            this.fixBoxStyleBorders();
             this.setupAccordion();
             this.setOpen();
             this.listenToContentChanges();
-        },
-
-        /**
-         * Styles are applied by default to editable areas of
-         * the editor. To make the element looks how you want, some styles
-         * need to be overwritten.
-         *
-         * Classes that are used are:
-         *      - .editable-text
-         *      - .paragraph
-         *      - .ui-wrapper
-         *      - .wsite-image
-         *      - .wsite-*
-         *      - (etc...)
-         */
-        fixStyles: function() {
-            this.$el.find('.editable-text').each(function(index) {
-                $(this).attr('style', '');
-            });
-
-            this.$el.find('.element').each(function(index) {
-                $(this).attr('style', '');
-            });
-
-            this.fixBoxStyleBorders();
         },
 
         /**

--- a/files/js/element.js
+++ b/files/js/element.js
@@ -7,33 +7,8 @@
         initialize: function() {
             this.activeIndex = this.settings.get('active_index');
 
-            this.fixStyles();
-            this.setupAccordion();
-        },
-
-        /**
-         * Styles are applied by default to editable areas of
-         * the editor. To make the element looks how you want, some styles
-         * need to be overwritten.
-         *
-         * Classes that are used are:
-         *      - .editable-text
-         *      - .paragraph
-         *      - .ui-wrapper
-         *      - .wsite-image
-         *      - .wsite-*
-         *      - (etc...)
-         */
-        fixStyles: function() {
-            this.$el.find('.editable-text').each(function(index) {
-                $(this).attr('style', '');
-            });
-
-            this.$el.find('.element').each(function(index) {
-                $(this).attr('style', '');
-            });
-
             this.fixBoxStyleBorders();
+            this.setupAccordion();
         },
 
         /**

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest": "1",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "locale": {
     "default": "en-us",
     "supported": [
@@ -11,7 +11,7 @@
     {
       "path": "files",
       "name": "FAQ",
-      "version": "1.3.0",
+      "version": "1.3.2",
       "settings": {
         "config": {},
         "properties": [


### PR DESCRIPTION
remove unnecessary fixStyles for the FAQ. All the stuff should start out as left-aligned anyway, so there's no real reason to run these style fixes.

Will be mirrored in the accordion soon.

@rchen1992 @M-Porter 