### PR TITLE
Prevent multiple click events from being bound

### DIFF
--- a/files/js/editor_element.js
+++ b/files/js/editor_element.js
@@ -64,7 +64,15 @@
         setupAccordion: function() {
             var view = this;
 
-            this.$el.find('.accordion__title').on('touchstart click', function(e) {
+            $titles = this.$el.find('.accordion__title');
+            $events = $._data($titles[0], "events");
+
+            // if we already have set up click events, don't set more up
+            if ($events && $events.click && $events.click[0]) {
+                return;
+            }
+
+            $titles.on('touchstart click', function(e) {
                 // remove "hover" state on touch events
                 if (e.type == "touchstart") {
                     view.$el.find('.accordion').removeClass('no-touch');

--- a/files/js/element.js
+++ b/files/js/element.js
@@ -18,7 +18,15 @@
         setupAccordion: function() {
             var view = this;
 
-            this.$el.find('.accordion__title').on('touchstart click', function(e) {
+            $titles = this.$el.find('.accordion__title');
+            $events = $._data($titles[0], "events");
+
+            // if we already have set up click events, don't set more up
+            if ($events && $events.click && $events.click[0]) {
+                return;
+            }
+
+            $titles.on('touchstart click', function(e) {
                 // remove "hover" state on touch events
                 if (e.type == "touchstart") {
                     view.$el.find('.accordion').removeClass('no-touch');

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest": "1",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "locale": {
     "default": "en-us",
     "supported": [
@@ -11,7 +11,7 @@
     {
       "path": "files",
       "name": "FAQ",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "settings": {
         "config": {},
         "properties": [


### PR DESCRIPTION
Checks to see if we've already bound click events once before, before trying to bind new ones.

@rchen1992 @szainmehdi 